### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tensorrt>=10.0.1
 onnx
+--extra-index-url https://pypi.nvidia.com


### PR DESCRIPTION
Add nvidia pip index to fix missing tensorrt bindings package.

Installing `tensorrt` no longer pulls in the required `tensorrt_bindings` package.  Adding nvidia's pypi index resolves this issue.

Current:
`python -s -m pip install "tensorrt>=10.0.1" --dry-run --force-reinstall`:
```
Collecting tensorrt>=10.0.1
  Using cached tensorrt-10.2.0.post1-py2.py3-none-any.whl
Collecting tensorrt-cu12==10.2.0.post1 (from tensorrt>=10.0.1)
  Using cached tensorrt_cu12-10.2.0.post1-py2.py3-none-any.whl
Would install tensorrt-10.2.0.post1 tensorrt-cu12-10.2.0.post1
```

New:
`python -s -m pip install "tensorrt>=10.0.1" --dry-run --force-reinstall --extra-index-url https://pypi.nvidia.com`:
```
Looking in indexes: https://pypi.org/simple, https://pypi.nvidia.com
Collecting tensorrt>=10.0.1
  Using cached https://pypi.nvidia.com/tensorrt/tensorrt-10.2.0.post1.tar.gz (16 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting tensorrt-cu12==10.2.0.post1 (from tensorrt>=10.0.1)
  Using cached https://pypi.nvidia.com/tensorrt-cu12/tensorrt-cu12-10.2.0.post1.tar.gz (18 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Collecting tensorrt-cu12-libs==10.2.0.post1 (from tensorrt-cu12==10.2.0.post1->tensorrt>=10.0.1)
  Using cached https://pypi.nvidia.com/tensorrt-cu12-libs/tensorrt_cu12_libs-10.2.0.post1-py2.py3-none-manylinux_2_17_x86_64.whl (2017.5 MB)
Collecting tensorrt-cu12-bindings==10.2.0.post1 (from tensorrt-cu12==10.2.0.post1->tensorrt>=10.0.1)
  Using cached https://pypi.nvidia.com/tensorrt-cu12-bindings/tensorrt_cu12_bindings-10.2.0.post1-cp310-none-manylinux_2_17_x86_64.whl (1.1 MB)
Collecting nvidia-cuda-runtime-cu12 (from tensorrt-cu12-libs==10.2.0.post1->tensorrt-cu12==10.2.0.post1->tensorrt>=10.0.1)
  Using cached https://pypi.nvidia.com/nvidia-cuda-runtime-cu12/nvidia_cuda_runtime_cu12-12.6.37-py3-none-manylinux2014_x86_64.whl (897 kB)
Would install nvidia-cuda-runtime-cu12-12.6.37 tensorrt-10.2.0.post1 tensorrt-cu12-10.2.0.post1 tensorrt-cu12-bindings-10.2.0.post1 tensorrt-cu12-libs-10.2.0.post1
```

Without this, you currently get something like this as an error (taken from SwarmUI):
```
03:36:05.547 [Warning] [ComfyUI-0/STDERR] Traceback (most recent call last):
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "/opt/comfyui/nodes.py", line 1941, in load_custom_node
03:36:05.547 [Warning] [ComfyUI-0/STDERR]     module_spec.loader.exec_module(module)
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "/opt/swarmui/src/BuiltinExtensions/ComfyUIBackend/DLNodes/ComfyUI_TensorRT/__init__.py", line 1, in <module>
03:36:05.547 [Warning] [ComfyUI-0/STDERR]     from .tensorrt_convert import DYNAMIC_TRT_MODEL_CONVERSION
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "/opt/swarmui/src/BuiltinExtensions/ComfyUIBackend/DLNodes/ComfyUI_TensorRT/tensorrt_convert.py", line 7, in <module>
03:36:05.547 [Warning] [ComfyUI-0/STDERR]     import tensorrt as trt
03:36:05.547 [Warning] [ComfyUI-0/STDERR]   File "/opt/comfyui/venv/lib/python3.10/site-packages/tensorrt/__init__.py", line 18, in <module>
03:36:05.547 [Warning] [ComfyUI-0/STDERR]     from tensorrt_bindings import *
03:36:05.547 [Warning] [ComfyUI-0/STDERR] ModuleNotFoundError: No module named 'tensorrt_bindings'
03:36:05.547 [Warning] [ComfyUI-0/STDERR] 
```